### PR TITLE
vocabhunter.github.io is also available using HTTPS, use it by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/VocabHunter/VocabHunter.svg?branch=master)](https://travis-ci.org/VocabHunter/VocabHunter)
 
-VocabHunter is a system to help learners of foreign languages.  The best place to go for information about VocabHunter is the project website: [vocabhunter.github.io](http://vocabhunter.github.io/).
+VocabHunter is a system to help learners of foreign languages.  The best place to go for information about VocabHunter is the project website: [vocabhunter.github.io](https://vocabhunter.github.io/).
 
 To get all the latest news about VocabHunter including announcements of new releases, follow [@vocabhunterapp](https://twitter.com/vocabhunterapp) on Twitter.
 
@@ -19,7 +19,7 @@ $ ./gradlew clean build
 
 # How To Run VocabHunter
 
-Go to the [download](http://vocabhunter.github.io/download/) page of the website to get the latest release of VocabHunter.  Alternatively, you can run the development version from the command line as follows:
+Go to the [download](https://vocabhunter.github.io/download/) page of the website to get the latest release of VocabHunter.  Alternatively, you can run the development version from the command line as follows:
 ~~~
 $ ./gradlew :gui:run
 ~~~

--- a/gui/src/main/java/io/github/vocabhunter/gui/common/GuiConstants.java
+++ b/gui/src/main/java/io/github/vocabhunter/gui/common/GuiConstants.java
@@ -7,7 +7,7 @@ package io.github.vocabhunter.gui.common;
 public final class GuiConstants {
     public static final String UNTITLED = "Untitled";
 
-    public static final String WEBSITE = "http://vocabhunter.github.io/";
+    public static final String WEBSITE = "https://vocabhunter.github.io/";
 
     public static final String WEBPAGE_HELP = WEBSITE + "help/";
 

--- a/gui/src/main/resources/about.fxml
+++ b/gui/src/main/resources/about.fxml
@@ -28,7 +28,7 @@
                         <Label text="VocabHunter is Open Source Software,&#10;published under the Apache Licence, Version 2.0." />
                         <Label fx:id="labelVersion" text="VocabHunter Version: %s." />
                         <Label text="Copyright (c) 2015 - 2016 Adam Carroll." />
-                        <Hyperlink fx:id="linkWebsite" text="http://vocabhunter.github.io/" styleClass="website" >
+                        <Hyperlink fx:id="linkWebsite" text="https://vocabhunter.github.io/" styleClass="website" >
                             <graphic>
                                 <FontAwesomeIconView styleClass="websiteIcon" />
                             </graphic>


### PR DESCRIPTION
Unfortunately GitHub does not yet redirect legacy HTTP to HTTPS which might result in users downloading VocabHunter via a unauthenticated connection which makes it very easy to exchange the VocabHunter program with a modified version using MITM.

Command used: `git ls-files -z | xargs --null -I '{}' find '{}' -type f -print0 | xargs --null sed --in-place --regexp-extended 's#http://vocabhunter\.github\.io#https://vocabhunter.github.io#g;'`

TODO:

* Update repo URL: https://github.com/VocabHunter/VocabHunter
* Update repo URL: https://github.com/VocabHunter/vocabhunter.github.io
* Update org URL: https://github.com/VocabHunter