### PR TITLE
add workaround for :gui:test crash on windows

### DIFF
--- a/gui/build.gradle
+++ b/gui/build.gradle
@@ -56,6 +56,6 @@ junitPlatform {
 
 junitPlatformTest {
     if (!project.hasProperty("noHeadless")) {
-        jvmArgs "-Dheadless=true"
+        jvmArgs "-Dheadless=true -Dprism.text=t2k"
     }
 }


### PR DESCRIPTION
Hi, I noticed that `gradle :gui:test` may cause JVM crashes on windows, see details: https://bugs.openjdk.java.net/browse/JDK-8087581